### PR TITLE
Update config files and enable docker toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@ The default configuration is minimal:
 
 *Note:* It is recommended that you link at least one source control system to drone, to enable the capability to login.
 
+The following example configuration enables Drone to authenticate off a Github Enterprise installation:
+
+	default['drone']['config'] = {
+	  'server' => {
+	    'port' => ':80',
+	  },
+	  'database' => {
+	    'driver' => 'sqlite3',
+	    'datasource' => '/var/lib/drone/drone.sqlite'
+	  },
+	  'github_enterprise' => {
+	    'client' => 'YOURCLIENT',
+	    'secret' => 'YOURSECRET',
+	    'api' => 'http://github.mycompany.com/api/v3/',
+	    'url' => 'http://github.mycompany.com',
+	    'private_mode' => true,
+	    'open' => true
+	  }
+	}
+
 There are many more configuration options that you can specify, and the complete config is shown below:
 
 	default['drone']['config'] = {

--- a/README.md
+++ b/README.md
@@ -48,11 +48,10 @@ The default configuration is minimal:
 	  'database' => {
 	    'driver' => 'sqlite3',
 	    'datasource' => '/var/lib/drone/drone.sqlite'
-	  },
-	  'registration' => {
-	    'open' => true
 	  }
 	}
+
+*Note:* It is recommended that you link at least one source control system to drone, to enable the capability to login.
 
 There are many more configuration options that you can specify, and the complete config is shown below:
 
@@ -62,6 +61,13 @@ There are many more configuration options that you can specify, and the complete
 	    'ssl' => {
 	      'key' => '',
 	      'cert' => ''
+	    },
+	    'assets' => {
+	      'folder' => ''
+	    },
+	    'session' => {
+	      'secret' => '',
+	      'expires' => ''
 	    }
 	  },
 	  'session' => {
@@ -72,26 +78,36 @@ There are many more configuration options that you can specify, and the complete
 	    'driver' => 'sqlite3',
 	    'datasource' => '/var/lib/drone/drone.sqlite'
 	  },
-	  'registration' => {
-	    'open' => true
-	  },
 	  'github' => {
 	    'client' => '',
-	    'secret' => ''
+	    'secret' => '',
+	    'orgs' => [],
+	    'open' => false
 	  },
 	  'github_enterprise' => {
 	    'client' => '',
 	    'secret' => '',
 	    'api' => '',
 	    'url' => '',
-	    'private_mode' => false
+	    'private_mode' => false,
+	    'open' => false
 	  },
 	  'bitbucket' => {
 	    'client' => '',
-	    'secret' => ''
+	    'secret' => '',
+	    'open' => false
 	  },
 	  'gitlab' => {
-	    'url' => ''
+	    'url' => '',
+	    'client' => '',
+	    'secret' => '',
+	    'skip_verify' => false,
+	    'open' => false
+	  },
+	  'gogs' => {
+	    'url' => '',
+	    'secret' => '',
+	    'open' => false
 	  },
 	  'smtp' => {
 	    'host' => '',
@@ -100,9 +116,11 @@ There are many more configuration options that you can specify, and the complete
 	    'user' => '',
 	    'pass' => ''
 	  },
-	  'worker' => {
+	  'docker' => {
 	    'cert' => '',
-	    'key' => '',
+	    'key' => ''
+	  },
+	  'worker' => {
 	    'nodes' => [
 	      'unix:///var/run/docker.sock'
 	    ]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,4 @@
+default['drone']['install_docker'] = true
 default['drone']['package_url'] = 'http://downloads.drone.io/master/drone.deb'
 default['drone']['temp_file'] = '/tmp/drone.deb'
 default['drone']['config_file'] = '/etc/init/drone.conf'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,8 +10,5 @@ default['drone']['config'] = {
   'database' => {
     'driver' => 'sqlite3',
     'datasource' => '/var/lib/drone/drone.sqlite'
-  },
-  'registration' => {
-    'open' => true
   }
 }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,11 +1,11 @@
-include_recipe "docker"
+include_recipe 'docker'
 
 remote_file node['drone']['temp_file'] do
   source node['drone']['package_url']
   action :create_if_missing
 end
 
-dpkg_package "drone" do
+dpkg_package 'drone' do
   source node['drone']['temp_file']
   action :install
 end
@@ -16,7 +16,7 @@ template 'drone.conf' do
   mode 0644
   owner 'root'
   group 'root'
-  notifies :restart, "service[drone]", :delayed
+  notifies :restart, 'service[drone]', :delayed
 end
 
 chef_gem 'toml'
@@ -27,14 +27,14 @@ file node['drone']['toml_file'] do
   mode 0644
   action :create
   content toml_string
-  notifies :restart, "service[drone]", :delayed
+  notifies :restart, 'service[drone]', :delayed
 end
 
-service "drone" do
+service 'drone' do
   provider Chef::Provider::Service::Upstart
   supports status: true, restart: true
   action [:enable, :start]
   restart_command 'service drone restart'
-  subscribes :restart, "template[drone.conf]", :immediately
+  subscribes :restart, 'template[drone.conf]', :immediately
   subscribes :restart, "file[#{node['drone']['toml_file']}]", :immediately
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,4 @@
-include_recipe 'docker'
+include_recipe 'docker' if node['drone']['install_docker']
 
 remote_file node['drone']['temp_file'] do
   source node['drone']['package_url']


### PR DESCRIPTION
This updates the config generation to match the new format from Drone.io, and also allows a toggle to disable installing docker on the same node (good for production deployments).

Quick code review would be great. Suggest we bump this to 0.6.0 for release.